### PR TITLE
first cut at capturing metrics

### DIFF
--- a/system_baseline/config.py
+++ b/system_baseline/config.py
@@ -8,7 +8,7 @@ inventory_svc_hostname = os.getenv(
 prometheus_multiproc_dir = os.getenv("prometheus_multiproc_dir", None)
 
 path_prefix = os.getenv("PATH_PREFIX", "/api/")
-app_name = os.getenv("APP_NAME", "system_baseline")
+app_name = os.getenv("APP_NAME", "system-baseline")
 
 
 _db_user = os.getenv("BASELINE_DB_USER", "insights")

--- a/system_baseline/metrics.py
+++ b/system_baseline/metrics.py
@@ -1,5 +1,21 @@
-from prometheus_client import Counter
+from prometheus_client import Counter, Histogram
 
 api_exceptions = Counter(
     "system_baseline_api_exceptions", "count of exceptions raised on public API"
+)
+
+baseline_create_requests = Histogram(
+    "baseline_create_requests", "baseline create request stats"
+)
+
+baseline_fetch_requests = Histogram(
+    "baseline_fetch_requests", "baseline fetch request stats"
+)
+
+baseline_fetch_all_requests = Histogram(
+    "baseline_fetch_all_requests", "baseline fetch all request stats"
+)
+
+baseline_delete_requests = Histogram(
+    "baseline_delete_requests", "baseline delete request stats"
 )

--- a/system_baseline/views/v0.py
+++ b/system_baseline/views/v0.py
@@ -33,6 +33,8 @@ def _build_json_response(json_data, status=200):
     return Response(json.dumps(json_data), status=status, mimetype="application/json")
 
 
+@metrics.baseline_fetch_requests.time()
+@metrics.api_exceptions.count_exceptions()
 def get_baselines_by_ids(baseline_ids, page=1, per_page=100):
     """
     return a list of baselines given their ID
@@ -50,6 +52,8 @@ def get_baselines_by_ids(baseline_ids, page=1, per_page=100):
     )
 
 
+@metrics.baseline_delete_requests.time()
+@metrics.api_exceptions.count_exceptions()
 def delete_baselines_by_ids(baseline_ids):
     """
     delete a list of baselines given their ID
@@ -62,6 +66,8 @@ def delete_baselines_by_ids(baseline_ids):
     db.session.commit()
 
 
+@metrics.baseline_fetch_all_requests.time()
+@metrics.api_exceptions.count_exceptions()
 def get_baselines(page=1, per_page=100):
     """
     return a list of baselines given their ID
@@ -77,6 +83,7 @@ def get_baselines(page=1, per_page=100):
     )
 
 
+@metrics.baseline_create_requests.time()
 @metrics.api_exceptions.count_exceptions()
 def create_baseline(system_baselines_list):
     """


### PR DESCRIPTION
This captures timings for a couple of URLs.

It also renames the URL from `system_baseline` to `system-baseline`.