### PR TITLE
allow viewing of openapi json for all users

### DIFF
--- a/system_baseline/views/v0.py
+++ b/system_baseline/views/v0.py
@@ -8,6 +8,7 @@ from system_baseline import metrics
 from system_baseline.models import SystemBaseline, db
 from system_baseline.constants import AUTH_HEADER_NAME
 from system_baseline.exceptions import HTTPError
+from system_baseline.config import path_prefix, app_name
 
 section = Blueprint("v0", __name__)
 
@@ -216,7 +217,7 @@ def _is_openapi_url(path):
     """
     small helper to test if URL is the openapi spec
     """
-    return path == "/api/system_baseline/v0/openapi.json"
+    return path == "%s%s/v0/openapi.json" % (path_prefix, app_name)
 
 
 @section.before_app_request


### PR DESCRIPTION
Previously we had the openapi json path hard-coded to
"system_baseline" instead of using `APP_NAME` and `PATH_PREFIX`. If
these variables were changed, the openapi json was no longer visible
to unauthenticated users.

This commit uses `APP_NAME` and `PATH_PREFIX` for the path check, so
this issue no longer happens.