### PR TITLE
make DB schema stricter

### DIFF
--- a/migrations/find_duplicate_account_display_name.sql
+++ b/migrations/find_duplicate_account_display_name.sql
@@ -1,0 +1,8 @@
+select
+  account, display_name, count(*)
+from
+  system_baselines
+group by
+  account, display_name
+having
+  count(*) > 1;

--- a/migrations/versions/16a84bebd064_add_additional_table_constraints.py
+++ b/migrations/versions/16a84bebd064_add_additional_table_constraints.py
@@ -1,0 +1,74 @@
+"""add additional table constraints
+
+Revision ID: 16a84bebd064
+Revises: e921ab7946b9
+Create Date: 2019-07-29 13:45:44.389108
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "16a84bebd064"
+down_revision = "e921ab7946b9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "system_baselines",
+        "account",
+        existing_type=sa.VARCHAR(length=10),
+        nullable=False,
+    )
+    op.alter_column(
+        "system_baselines",
+        "created_on",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=False,
+    )
+    op.alter_column(
+        "system_baselines",
+        "display_name",
+        existing_type=sa.VARCHAR(length=200),
+        nullable=False,
+    )
+    op.alter_column(
+        "system_baselines",
+        "modified_on",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=False,
+    )
+    op.create_unique_constraint(
+        "_account_display_name_uc", "system_baselines", ["account", "display_name"]
+    )
+
+
+def downgrade():
+    op.drop_constraint("_account_display_name_uc", "system_baselines", type_="unique")
+    op.alter_column(
+        "system_baselines",
+        "modified_on",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=True,
+    )
+    op.alter_column(
+        "system_baselines",
+        "display_name",
+        existing_type=sa.VARCHAR(length=200),
+        nullable=True,
+    )
+    op.alter_column(
+        "system_baselines",
+        "created_on",
+        existing_type=postgresql.TIMESTAMP(),
+        nullable=True,
+    )
+    op.alter_column(
+        "system_baselines",
+        "account",
+        existing_type=sa.VARCHAR(length=10),
+        nullable=True,
+    )

--- a/system_baseline/models.py
+++ b/system_baseline/models.py
@@ -3,19 +3,24 @@ from datetime import datetime
 
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.schema import UniqueConstraint
 
 db = SQLAlchemy()
 
 
 class SystemBaseline(db.Model):
     __tablename__ = "system_baselines"
+    # do not allow two records in the same account to have the same display name
+    __table_args__ = (
+        UniqueConstraint("account", "display_name", name="_account_display_name_uc"),
+    )
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    account = db.Column(db.String(10))
-    display_name = db.Column(db.String(200))
-    created_on = db.Column(db.DateTime, default=datetime.utcnow)
+    account = db.Column(db.String(10), nullable=False)
+    display_name = db.Column(db.String(200), nullable=False)
+    created_on = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
     modified_on = db.Column(
-        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
     )
     baseline_facts = db.Column(JSONB)
 

--- a/system_baseline/openapi/api.spec.yaml
+++ b/system_baseline/openapi/api.spec.yaml
@@ -44,10 +44,8 @@ paths:
         content:
           application/json:
             schema:
-              x-body-name: system_baseline_list
-              type: array
-              items:
-                $ref: "#/components/schemas/BaselineIn"
+              $ref: "#/components/schemas/BaselineIn"
+              x-body-name: system_baseline_in
       responses:
         '200':
           description: a list of created Baseline objects


### PR DESCRIPTION
Do not allow null values in more fields. Also, do not allow duplicate
account numbers + display_names for baselines.

This commit changes the way records are POSTed. We allow only one
record to be created at a time for now, so we can give better error
messages.