### PR TITLE
fix POSTing of a new baseline

### DIFF
--- a/system_baseline/openapi/api.spec.yaml
+++ b/system_baseline/openapi/api.spec.yaml
@@ -44,13 +44,11 @@ paths:
               x-body-name: system_baseline_in
       responses:
         '200':
-          description: a list of created Baseline objects
+          description: a created baseline object
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Baseline"
+                $ref: "#/components/schemas/Baseline"
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':


### PR DESCRIPTION
I forgot to update the API spec to remove the array from POST results.
This commit fixes that.