### PR TITLE
handle None/"None" from inv service

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -148,10 +148,12 @@ BASELINE_PARTIAL_TWO = {
         }
     ],
 }
+BASELINE_PARTIAL_CONFLICT = {"display_name": "arch baseline"}
 CREATE_FROM_INVENTORY = {
     "display_name": "created_from_inventory",
     "inventory_uuid": "df925152-c45d-11e9-a1f0-c85b761454fa",
 }
+
 
 SYSTEM_WITH_PROFILE = {
     "account": "9876543",

--- a/tests/test_v0_api.py
+++ b/tests/test_v0_api.py
@@ -129,6 +129,20 @@ class ApiPatchTests(unittest.TestCase):
                 self.assertNotIn("value", fact)  # confirm we got rid of non-nested data
                 self.assertEqual(len(fact["values"]), 2)
 
+        # create a second baseline
+        self.client.post(
+            "api/system-baseline/v0/baselines",
+            headers=fixtures.AUTH_HEADER,
+            json=fixtures.BASELINE_ONE_LOAD,
+        )
+        # attempt to rename the first baseline to the second
+        response = self.client.patch(
+            "api/system-baseline/v0/baselines/%s" % patched_uuid,
+            headers=fixtures.AUTH_HEADER,
+            json=fixtures.BASELINE_PARTIAL_CONFLICT,
+        )
+        self.assertEqual(response.status_code, 400)
+
 
 class CreateFromInventoryTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This commit handles the values None and "None" properly from inventory
service for system profile facts.

Additionally, it will raise a 400 error if you attempt to rename
baseline's display_name to one that is already taken.