### PR TITLE
return a better error message if name is taken

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -151,7 +151,7 @@ BASELINE_PATCH = {
     ],
 }
 
-BASELINE_PARTIAL_CONFLICT = {"display_name": "arch baseline"}
+BASELINE_PARTIAL_CONFLICT = {"display_name": "arch baseline", "facts_patch": []}
 CREATE_FROM_INVENTORY = {
     "display_name": "created_from_inventory",
     "inventory_uuid": "df925152-c45d-11e9-a1f0-c85b761454fa",


### PR DESCRIPTION
Previously, we were returning a 500 error if a baseline's name was
already taken during a PATCH.

Instead, return a 400 with error message. We already had a unit test
for this but the test was (correctly) returning a 400 because I was
sending in a malformed request. The test has been adjusted to test for
the correct error scenario.