### PR TITLE
refactor validators

### DIFF
--- a/system_baseline/exceptions.py
+++ b/system_baseline/exceptions.py
@@ -15,3 +15,14 @@ class HTTPError(Exception):
         super(HTTPError, self).__init__()
         self.message = message
         self.status_code = status_code
+
+
+class FactValidationError(Exception):
+    def __init__(self, message=""):
+        """
+        Raise this exception for fact validation errors
+
+        :param message:     optional error message for the exception
+        """
+        super(FactValidationError, self).__init__()
+        self.message = message

--- a/system_baseline/models.py
+++ b/system_baseline/models.py
@@ -6,6 +6,8 @@ from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.schema import UniqueConstraint
 from sqlalchemy.orm import validates
 
+from system_baseline import validators
+
 db = SQLAlchemy()
 
 FACTS_MAXSIZE = 2 ** 19  # 512KB
@@ -32,9 +34,9 @@ class SystemBaseline(db.Model):
         return len(self.baseline_facts)
 
     @validates("baseline_facts")
-    def validate_facts_length(self, key, value):
-        if len(str(value)) > FACTS_MAXSIZE:
-            raise RuntimeError("attempted to save fact list over %s" % FACTS_MAXSIZE)
+    def validate_facts(self, key, value):
+        validators.check_facts_length(value)
+        validators.check_for_duplicate_names(value)
         return value
 
     def __init__(self, baseline_facts, display_name=display_name, account=account):

--- a/system_baseline/validators.py
+++ b/system_baseline/validators.py
@@ -1,0 +1,43 @@
+from uuid import UUID
+
+from system_baseline.exceptions import FactValidationError
+
+FACTS_MAXSIZE = 2 ** 19  # 512KB
+
+
+def check_for_duplicate_names(facts):
+    """
+    check if any names are duplicated; raises an exception if duplicates are found.
+    """
+    names = []
+    for fact in facts:
+        if "value" in fact:
+            names.append(fact["name"])
+        elif "values" in fact:
+            check_for_duplicate_names(fact["values"])
+
+    for name in names:
+        if names.count(name) > 1:
+            raise FactValidationError("name %s declared more than once" % name)
+
+
+def check_facts_length(facts):
+    """
+    check if fact length is greater than FACTS_MAXSIZE
+    """
+    if len(str(facts)) > FACTS_MAXSIZE:
+        raise FactValidationError(
+            "attempted to save fact list over %s bytes" % FACTS_MAXSIZE
+        )
+
+
+def check_uuids(baseline_ids):
+    """
+    helper method to test if a UUID is properly formatted. Will raise an
+    exception if format is wrong.
+    """
+    for baseline_id in baseline_ids:
+        try:
+            UUID(baseline_id)
+        except ValueError as e:
+            raise e

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -134,6 +134,31 @@ BASELINE_THREE_LOAD = {
     ],
     "display_name": "cpu + mem baseline",
 }
+BASELINE_DUPLICATES_LOAD = {
+    "baseline_facts": [
+        {"name": "memory", "value": "64GB"},
+        {"name": "memory", "value": "128GB"},
+        {
+            "name": "nested",
+            "values": [
+                {"name": "nested_cpu_sockets", "value": "16"},
+                {"name": "nested_cpu_sockets", "value": "32"},
+            ],
+        },
+        {"name": "cpu_sockets", "value": "16"},
+    ],
+    "display_name": "duplicate cpu + mem baseline",
+}
+
+BASELINE_DUPLICATES_TWO_LOAD = {
+    "baseline_facts": [
+        {"name": "memory", "value": "64GB"},
+        {"name": "memory", "value": "128GB"},
+        {"name": "cpu_sockets", "value": "16"},
+    ],
+    "display_name": "duplicate cpu + mem baseline",
+}
+
 
 BASELINE_PATCH = {
     "display_name": "ABCDE",


### PR DESCRIPTION
This commit refactors validators into validators.py. It also adds a
check to ensure two facts do not have the same name in a baseline
before saving, and raises a 400 with message if this happens.