### PR TITLE
check category and fact names for duplication

### DIFF
--- a/system_baseline/validators.py
+++ b/system_baseline/validators.py
@@ -11,9 +11,8 @@ def check_for_duplicate_names(facts):
     """
     names = []
     for fact in facts:
-        if "value" in fact:
-            names.append(fact["name"])
-        elif "values" in fact:
+        names.append(fact["name"])
+        if "values" in fact:
             check_for_duplicate_names(fact["values"])
 
     for name in names:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -137,7 +137,6 @@ BASELINE_THREE_LOAD = {
 BASELINE_DUPLICATES_LOAD = {
     "baseline_facts": [
         {"name": "memory", "value": "64GB"},
-        {"name": "memory", "value": "128GB"},
         {
             "name": "nested",
             "values": [
@@ -159,6 +158,14 @@ BASELINE_DUPLICATES_TWO_LOAD = {
     "display_name": "duplicate cpu + mem baseline",
 }
 
+BASELINE_DUPLICATES_THREE_LOAD = {
+    "baseline_facts": [
+        {"name": "memory", "value": "128GB"},
+        {"name": "memory", "values": [{"name": "nested_cpu_sockets", "value": "32"}]},
+        {"name": "cpu_sockets", "value": "16"},
+    ],
+    "display_name": "duplicate cpu + mem baseline",
+}
 
 BASELINE_PATCH = {
     "display_name": "ABCDE",

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -320,11 +320,22 @@ class ApiDuplicateTests(unittest.TestCase):
             headers=fixtures.AUTH_HEADER,
             json=fixtures.BASELINE_DUPLICATES_LOAD,
         )
-        self.assertIn("declared more than once", response.data.decode("utf-8"))
+        self.assertIn(
+            "name nested_cpu_sockets declared more than once",
+            response.data.decode("utf-8"),
+        )
 
         response = self.client.post(
             "api/system-baseline/v1/baselines",
             headers=fixtures.AUTH_HEADER,
             json=fixtures.BASELINE_DUPLICATES_TWO_LOAD,
         )
+        self.assertIn("memory declared more than once", response.data.decode("utf-8"))
+
+        response = self.client.post(
+            "api/system-baseline/v1/baselines",
+            headers=fixtures.AUTH_HEADER,
+            json=fixtures.BASELINE_DUPLICATES_THREE_LOAD,
+        )
+        self.assertEqual(response.status_code, 400)
         self.assertIn("memory declared more than once", response.data.decode("utf-8"))


### PR DESCRIPTION
Previously, we only checked if non-category facts were being
duplicated.  This inadvertently allowed users to create a category and
fact with the same name.

Instead, check that all top-level names are different (across both
facts and categories).