### PR TITLE
sort baseline facts in responses

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -167,6 +167,22 @@ BASELINE_DUPLICATES_THREE_LOAD = {
     "display_name": "duplicate cpu + mem baseline",
 }
 
+BASELINE_UNSORTED_LOAD = {
+    "baseline_facts": [
+        {"name": "A-name", "value": "64GB"},
+        {"name": "C-name", "value": "128GB"},
+        {
+            "name": "B-name",
+            "values": [
+                {"name": "B-nested_cpu_sockets", "value": "32"},
+                {"name": "A-nested_cpu_sockets", "value": "32"},
+            ],
+        },
+        {"name": "D-name", "value": "16"},
+    ],
+    "display_name": "duplicate cpu + mem baseline",
+}
+
 BASELINE_PATCH = {
     "display_name": "ABCDE",
     "facts_patch": [


### PR DESCRIPTION
Previously, we were not sorting the baseline facts. This caused issues
where adding new facts might appear anywhere in the web UI.

We now sort facts by 'name' by default.