### PR TITLE
use lowercase sorting for baseline fact names

### DIFF
--- a/system_baseline/views/v1.py
+++ b/system_baseline/views/v1.py
@@ -337,10 +337,14 @@ def _sort_baseline_facts(baseline_facts):
     """
     helper method to sort baseline facts by name before saving to the DB.
     """
-    sorted_baseline_facts = sorted(baseline_facts, key=lambda fact: fact["name"])
+    sorted_baseline_facts = sorted(
+        baseline_facts, key=lambda fact: fact["name"].lower()
+    )
     for fact in sorted_baseline_facts:
         if "values" in fact:
-            fact["values"] = sorted(fact["values"], key=lambda fact: fact["name"])
+            fact["values"] = sorted(
+                fact["values"], key=lambda fact: fact["name"].lower()
+            )
     return sorted_baseline_facts
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -174,8 +174,9 @@ BASELINE_UNSORTED_LOAD = {
         {
             "name": "B-name",
             "values": [
-                {"name": "B-nested_cpu_sockets", "value": "32"},
-                {"name": "A-nested_cpu_sockets", "value": "32"},
+                {"name": "b-nested_cpu_sockets", "value": "32"},
+                {"name": "Z-nested_cpu_sockets", "value": "32"},
+                {"name": "a-nested_cpu_sockets", "value": "32"},
             ],
         },
         {"name": "D-name", "value": "16"},

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -109,8 +109,9 @@ class ApiSortTests(unittest.TestCase):
                 {
                     "name": "B-name",
                     "values": [
-                        {"name": "A-nested_cpu_sockets", "value": "32"},
-                        {"name": "B-nested_cpu_sockets", "value": "32"},
+                        {"name": "a-nested_cpu_sockets", "value": "32"},
+                        {"name": "b-nested_cpu_sockets", "value": "32"},
+                        {"name": "Z-nested_cpu_sockets", "value": "32"},
                     ],
                 },
                 {"name": "C-name", "value": "128GB"},


### PR DESCRIPTION
We were previously not removing uppercase/lowercase before sorting, so
"Z" came before "a".

This commit lowers all comparisons, so "a" comes before "Z".