### PR TITLE
do not allow null display_name when copying

### DIFF
--- a/system_baseline/views/v1.py
+++ b/system_baseline/views/v1.py
@@ -356,6 +356,12 @@ def copy_baseline_by_id(baseline_id, display_name):
     """
     _validate_uuids([baseline_id])
 
+    # ensure display_name is not null
+    if not display_name:
+        raise HTTPError(
+            HTTPStatus.BAD_REQUEST, message="no value given for display_name"
+        )
+
     account_number = view_helpers.get_account_number(request)
     query = SystemBaseline.query.filter(
         SystemBaseline.account == account_number, SystemBaseline.id == baseline_id

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -230,6 +230,12 @@ class CopyBaselineTests(unittest.TestCase):
         source_uuid = result["data"][0]["id"]
 
         response = self.client.post(
+            "api/system-baseline/v1/baselines/%s?display_name=" % source_uuid,
+            headers=fixtures.AUTH_HEADER,
+        )
+        self.assertEqual(response.status_code, 400)
+
+        response = self.client.post(
             "api/system-baseline/v1/baselines/%s?display_name=copy" % source_uuid,
             headers=fixtures.AUTH_HEADER,
         )


### PR DESCRIPTION
For some reason, if an empty display_name is sent via query param,
it's getting passed through openapi to the app, and can create an
empty display_name.

We now validate that the display_name is not empty before we copy a
baseline. This check is only needed for copy and not create, since
create's display_name is validated correctly elsewhere.