### PR TITLE
return a 400, not 500 for incorrect baseline copy

### DIFF
--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -242,6 +242,12 @@ class CopyBaselineTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         copied_baseline = json.loads(response.data)
 
+        response = self.client.post(
+            "api/system-baseline/v1/baselines/%s?display_name=copy" % source_uuid,
+            headers=fixtures.AUTH_HEADER,
+        )
+        self.assertEqual(response.status_code, 400)
+
         response = self.client.get(
             "api/system-baseline/v1/baselines/%s" % source_uuid,
             headers=fixtures.AUTH_HEADER,


### PR DESCRIPTION
If an API user attempts to copy a baseline to a display_name that
already exists, we would previously return a 500 error.

Instead, return a 400 with a useful error message.