### PR TITLE
allow deletion of multiple UUIDs

### DIFF
--- a/system_baseline/openapi/api.spec.yaml
+++ b/system_baseline/openapi/api.spec.yaml
@@ -34,6 +34,28 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/InternalServerError'
+    delete:
+      summary: delete one or more baselines
+      description: "delete one or more baselines"
+      operationId: system_baseline.views.v1.delete_baselines_by_list
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BaselineIdsList"
+              x-body-name: baseline_ids_list
+      responses:
+        '200':
+          description: a success message
+          content:
+            application/json:
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     post:
       summary: create a baseline
       description: "create a baseline"
@@ -274,6 +296,18 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/BaselineFact"
+    BaselineIdsList:
+      type: object
+      additionalProperties: false
+      required:
+        - baseline_ids
+      properties:
+        baseline_ids:
+          type: array
+          items:
+            type: string
+            minLength: 32
+            maxLength: 36
     JsonPatch:
       description: a JSON patch
       type: object

--- a/system_baseline/views/v1.py
+++ b/system_baseline/views/v1.py
@@ -145,13 +145,32 @@ def delete_baselines_by_ids(baseline_ids):
     delete a list of baselines given their ID
     """
     _validate_uuids(baseline_ids)
+    _delete_baselines(baseline_ids)
+    return "OK"
+
+
+@metrics.baseline_delete_requests.time()
+@metrics.api_exceptions.count_exceptions()
+def delete_baselines_by_list(baseline_ids_list):
+    """
+    delete a list of baselines given their IDs as a list
+    """
+    baseline_ids = baseline_ids_list["baseline_ids"]
+    _validate_uuids(baseline_ids)
+    _delete_baselines(baseline_ids)
+    return "OK"
+
+
+def _delete_baselines(baseline_ids):
+    """
+    delete baselines
+    """
     account_number = view_helpers.get_account_number(request)
     query = SystemBaseline.query.filter(
         SystemBaseline.account == account_number, SystemBaseline.id.in_(baseline_ids)
     )
     query.delete(synchronize_session="fetch")
     db.session.commit()
-    return "OK"
 
 
 def _create_ordering(order_by, order_how, query):


### PR DESCRIPTION
Previously, users were able to delete multiple baselines at once via
URL. However, this can hit URL length limits.

This commit allows sending a DELETE with `baseline_ids` like so:

```json
{"baseline_ids": ["uuid1", "uuid2"]}
```