### PR TITLE
use sqlalchemy autoescape

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -30,7 +30,6 @@ flask-migrate = "*"
 kerlescan = {editable = true,git = "https://github.com/beav/kerlescan.git",ref = "0.3"}
 bitmath = "*"
 jsonpatch = "*"
-sqlalchemy-utils = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6d3928046950f17fbd833b494b659a64a47f0f007aca67c58c1994f4e1daeff5"
+            "sha256": "cd39fa1507d8ac1678dbdc80a0444160b4b1bdcf81ee7093cab98190e65b4d2f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -32,18 +32,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:7fc97cb2c9cdff905e950750c8e8b23b872a84696158a28852355dc4b712ba3a",
-                "sha256:818c56a317c176142dbf1dca3f5b4366c80460c6cc3c4efe22f0bde736571283"
+                "sha256:03130f43e15f02af7040946f7d4ebbba410fba5ee210b48ca8ba8407d2960b87",
+                "sha256:0b294a58635ed882a3821854f00264e6b3e65f2114c85c64109ad2280c7d5608"
             ],
             "index": "pypi",
-            "version": "==1.10.2"
+            "version": "==1.10.5"
         },
         "botocore": {
             "hashes": [
-                "sha256:8223485841ef4731a5d4943a733295ba69d0005c4ae64c468308cc07f6960d39",
-                "sha256:f8e12dc6e536ea512f0ad25b74e7eecdf5d9e09ae92b5de236b535bee7804d5b"
+                "sha256:13bf9d0d9b9cda278349c9ba0c35c96570795438d5bd29e5188e110b3f5a5183",
+                "sha256:cfce2c7d6a218d693ed6daa8a41040761e35d7a728d1cf43ae14c4132fb146f3"
             ],
-            "version": "==1.13.2"
+            "version": "==1.13.5"
         },
         "certifi": {
             "hashes": [
@@ -323,13 +323,6 @@
             ],
             "version": "==1.3.10"
         },
-        "sqlalchemy-utils": {
-            "hashes": [
-                "sha256:6689b29d7951c5c7c4d79fa6b8c95f9ff9ec708b07aa53f82060599bd14dcc88"
-            ],
-            "index": "pypi",
-            "version": "==0.34.2"
-        },
         "swagger-ui-bundle": {
             "hashes": [
                 "sha256:01ae8fdb1fa4e034933e0874afdda0d433dcb94476fccb231b66fd5f49dac96c",
@@ -386,11 +379,11 @@
         },
         "black": {
             "hashes": [
-                "sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf",
-                "sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c"
+                "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b",
+                "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"
             ],
             "index": "pypi",
-            "version": "==19.3b0"
+            "version": "==19.10b0"
         },
         "certifi": {
             "hashes": [
@@ -446,10 +439,10 @@
         },
         "decorator": {
             "hashes": [
-                "sha256:86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de",
-                "sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"
+                "sha256:54c38050039232e1db4ad7375cfce6748d7b41c29e95a081c8a6d2c30364a2ce",
+                "sha256:5d19b92a3c8f7f101c8dd86afd86b0f061a8ce4540ab8cd401fa2542756bce6d"
             ],
-            "version": "==4.4.0"
+            "version": "==4.4.1"
         },
         "entrypoints": {
             "hashes": [
@@ -460,11 +453,11 @@
         },
         "flake8": {
             "hashes": [
-                "sha256:19241c1cbc971b9962473e4438a2ca19749a7dd002dd1a946eaba171b4114548",
-                "sha256:8e9dfa3cecb2400b3738a42c54c3043e821682b9c840b0448c0503f781130696"
+                "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb",
+                "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"
             ],
             "index": "pypi",
-            "version": "==3.7.8"
+            "version": "==3.7.9"
         },
         "idna": {
             "hashes": [
@@ -489,10 +482,10 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:c4ab005921641e40a68e405e286e7a1fcc464497e14d81b6914b4fd95e5dee9b",
-                "sha256:dd76831f065f17bddd7eaa5c781f5ea32de5ef217592cf019e34043b56895aa1"
+                "sha256:dfd303b270b7b5232b3d08bd30ec6fd685d8a58cabd54055e3d69d8f029f7280",
+                "sha256:ed7ebe1cba899c1c3ccad6f7f1c2d2369464cc77dba8eebc65e2043e19cda995"
             ],
-            "version": "==7.8.0"
+            "version": "==7.9.0"
         },
         "ipython-genutils": {
             "hashes": [
@@ -628,9 +621,9 @@
         },
         "pyrsistent": {
             "hashes": [
-                "sha256:34b47fa169d6006b32e99d4b3c4031f155e6e68ebcc107d6454852e8e0ee6533"
+                "sha256:eb6545dbeb1aa69ab1fb4809bfbf5a8705e44d92ef8fc7c2361682a47c46c778"
             ],
-            "version": "==0.15.4"
+            "version": "==0.15.5"
         },
         "pyyaml": {
             "hashes": [
@@ -649,6 +642,22 @@
                 "sha256:f81025eddd0327c7d4cfe9b62cf33190e1e736cc6e97502b3ec425f574b3e7a8"
             ],
             "version": "==5.1.2"
+        },
+        "regex": {
+            "hashes": [
+                "sha256:1e9f9bc44ca195baf0040b1938e6801d2f3409661c15fe57f8164c678cfc663f",
+                "sha256:587b62d48ca359d2d4f02d486f1f0aa9a20fbaf23a9d4198c4bed72ab2f6c849",
+                "sha256:835ccdcdc612821edf132c20aef3eaaecfb884c9454fdc480d5887562594ac61",
+                "sha256:93f6c9da57e704e128d90736430c5c59dd733327882b371b0cae8833106c2a21",
+                "sha256:a46f27d267665016acb3ec8c6046ec5eae8cf80befe85ba47f43c6f5ec636dcd",
+                "sha256:c5c8999b3a341b21ac2c6ec704cfcccbc50f1fedd61b6a8ee915ca7fd4b0a557",
+                "sha256:d4d1829cf97632673aa49f378b0a2c3925acd795148c5ace8ef854217abbee89",
+                "sha256:d96479257e8e4d1d7800adb26bf9c5ca5bab1648a1eddcac84d107b73dc68327",
+                "sha256:f20f4912daf443220436759858f96fefbfc6c6ba9e67835fd6e4e9b73582791a",
+                "sha256:f2b37b5b2c2a9d56d9e88efef200ec09c36c7f323f9d58d0b985a90923df386d",
+                "sha256:fe765b809a1f7ce642c2edeee351e7ebd84391640031ba4b60af8d91a9045890"
+            ],
+            "version": "==2019.8.19"
         },
         "requests": {
             "hashes": [
@@ -685,6 +694,31 @@
                 "sha256:d023ee369ddd2763310e4c3eae1ff649689440d4ae59d7485eb4cfbbe3e359f7"
             ],
             "version": "==4.3.3"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:1170afa46a3799e18b4c977777ce137bb53c7485379d9706af8a59f2ea1aa161",
+                "sha256:18511a0b3e7922276346bcb47e2ef9f38fb90fd31cb9223eed42c85d1312344e",
+                "sha256:262c247a82d005e43b5b7f69aff746370538e176131c32dda9cb0f324d27141e",
+                "sha256:2b907eb046d049bcd9892e3076c7a6456c93a25bebfe554e931620c90e6a25b0",
+                "sha256:354c16e5babd09f5cb0ee000d54cfa38401d8b8891eefa878ac772f827181a3c",
+                "sha256:48e5b1e71f25cfdef98b013263a88d7145879fbb2d5185f2a0c79fa7ebbeae47",
+                "sha256:4e0b70c6fc4d010f8107726af5fd37921b666f5b31d9331f0bd24ad9a088e631",
+                "sha256:630968c5cdee51a11c05a30453f8cd65e0cc1d2ad0d9192819df9978984529f4",
+                "sha256:66480f95b8167c9c5c5c87f32cf437d585937970f3fc24386f313a4c97b44e34",
+                "sha256:71211d26ffd12d63a83e079ff258ac9d56a1376a25bc80b1cdcdf601b855b90b",
+                "sha256:7954560051331d003b4e2b3eb822d9dd2e376fa4f6d98fee32f452f52dd6ebb2",
+                "sha256:838997f4310012cf2e1ad3803bce2f3402e9ffb71ded61b5ee22617b3a7f6b6e",
+                "sha256:95bd11af7eafc16e829af2d3df510cecfd4387f6453355188342c3e79a2ec87a",
+                "sha256:bc6c7d3fa1325a0c6613512a093bc2a2a15aeec350451cbdf9e1d4bffe3e3233",
+                "sha256:cc34a6f5b426748a507dd5d1de4c1978f2eb5626d51326e43280941206c209e1",
+                "sha256:d755f03c1e4a51e9b24d899561fec4ccaf51f210d52abdf8c07ee2849b212a36",
+                "sha256:d7c45933b1bdfaf9f36c579671fec15d25b06c8398f113dab64c18ed1adda01d",
+                "sha256:d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a",
+                "sha256:fdc1c9bbf79510b76408840e009ed65958feba92a88833cdceecff93ae8fff66",
+                "sha256:ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12"
+            ],
+            "version": "==1.4.0"
         },
         "urllib3": {
             "hashes": [

--- a/system_baseline-manifest
+++ b/system_baseline-manifest
@@ -1,7 +1,7 @@
 system_baseline/python:3.6=alembic:1.2.1
 system_baseline/python:3.6=bitmath:1.3.3.1
-system_baseline/python:3.6=boto3:1.10.2
-system_baseline/python:3.6=botocore:1.13.2
+system_baseline/python:3.6=boto3:1.10.5
+system_baseline/python:3.6=botocore:1.13.5
 system_baseline/python:3.6=certifi:2019.9.11
 system_baseline/python:3.6=chardet:3.0.4
 system_baseline/python:3.6=click:7.0
@@ -34,7 +34,6 @@ system_baseline/python:3.6=requests:2.22.0
 system_baseline/python:3.6=s3transfer:0.2.1
 system_baseline/python:3.6=six:1.12.0
 system_baseline/python:3.6=sqlalchemy:1.3.10
-system_baseline/python:3.6=sqlalchemy-utils:0.34.2
 system_baseline/python:3.6=swagger-ui-bundle:0.0.5
 system_baseline/python:3.6=urllib3:1.25.6
 system_baseline/python:3.6=watchtower:0.7.3

--- a/system_baseline/views/v1.py
+++ b/system_baseline/views/v1.py
@@ -5,7 +5,6 @@ import jsonpatch
 import jsonpointer
 
 from sqlalchemy.orm.session import make_transient
-from sqlalchemy_utils import escape_like
 
 from kerlescan import view_helpers
 from kerlescan import profile_parser
@@ -208,7 +207,7 @@ def get_baselines(limit, offset, order_by, order_how, display_name=None):
 
     if display_name:
         query = query.filter(
-            SystemBaseline.display_name.contains(escape_like(display_name))
+            SystemBaseline.display_name.contains(display_name, autoescape=True)
         )
 
     total_count = query.count()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -134,6 +134,12 @@ BASELINE_THREE_LOAD = {
     ],
     "display_name": "cpu + mem baseline",
 }
+BASELINE_UNDERSCORE_LOAD = {
+    "baseline_facts": [
+        {"name": "nested", "values": [{"name": "cpu_sockets", "value": "16"}]}
+    ],
+    "display_name": "has_an_underscore",
+}
 BASELINE_DUPLICATES_LOAD = {
     "baseline_facts": [
         {"name": "memory", "value": "64GB"},

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -231,6 +231,21 @@ class ApiTests(unittest.TestCase):
         result = json.loads(response.data)
         self.assertEqual(result["meta"]["count"], 0)
 
+        response = self.client.post(
+            "api/system-baseline/v1/baselines",
+            headers=fixtures.AUTH_HEADER,
+            json=fixtures.BASELINE_UNDERSCORE_LOAD,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get(
+            "api/system-baseline/v1/baselines?display_name=has_an_underscore",
+            headers=fixtures.AUTH_HEADER,
+        )
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.data)
+        self.assertEqual(result["meta"]["count"], 1)
+
 
 class CopyBaselineTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Previously, we were escaping underscores incorrectly using
`escape_like`. Instead, use `autoescape=True` which seems to do the
right thing in all cases.