### PR TITLE
return a 400 for missing inventory uuid

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -229,9 +229,20 @@ BASELINE_PATCH_EMPTY_NAME = {
 
 
 BASELINE_PARTIAL_CONFLICT = {"display_name": "arch baseline", "facts_patch": []}
+# >200 char in display_name
+BASELINE_PATCH_LONG_NAME = {
+    "display_name": "arch baseline33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333",  # noqa: E501
+    "facts_patch": [],
+}
 BASELINE_TOUCH = {"display_name": "updated baseline", "facts_patch": []}
 CREATE_FROM_INVENTORY = {
     "display_name": "created_from_inventory",
+    "inventory_uuid": "df925152-c45d-11e9-a1f0-c85b761454fa",
+}
+
+# >200 chars in display_name
+CREATE_FROM_INVENTORY_LONG_NAME = {
+    "display_name": "created_from_inventoryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",  # noqa: E501
     "inventory_uuid": "df925152-c45d-11e9-a1f0-c85b761454fa",
 }
 


### PR DESCRIPTION
Previously, we would raise a 500 error if someone tried to clone a
baseline from an inventory UUID that did not exist or was not
accesssible.

Instead, raise a 400 with appropriate error message.