### PR TITLE
perform additional validation when patching

### DIFF
--- a/system_baseline/validators.py
+++ b/system_baseline/validators.py
@@ -20,6 +20,19 @@ def check_for_duplicate_names(facts):
             raise FactValidationError("name %s declared more than once" % name)
 
 
+def check_for_empty_name_values(facts):
+    """
+    check if any names are duplicated; raises an exception if duplicates are found.
+    """
+    for fact in facts:
+        if "values" in fact:
+            check_for_empty_name_values(fact["values"])
+        elif "name" in fact and not fact["name"]:
+            raise FactValidationError("empty name in fact set")
+        elif "value" in fact and not fact["value"]:
+            raise FactValidationError("empty value in fact set for %s" % fact["name"])
+
+
 def check_facts_length(facts):
     """
     check if fact length is greater than FACTS_MAXSIZE

--- a/system_baseline/views/v1.py
+++ b/system_baseline/views/v1.py
@@ -321,6 +321,7 @@ def create_baseline(system_baseline_in):
     try:
         validators.check_facts_length(baseline_facts)
         validators.check_for_duplicate_names(baseline_facts)
+        validators.check_for_empty_name_values(baseline_facts)
     except FactValidationError as e:
         raise HTTPError(HTTPStatus.BAD_REQUEST, message=e.message)
 
@@ -447,7 +448,11 @@ def update_baseline(baseline_id, system_baseline_patch):
             baseline.baseline_facts, system_baseline_patch["facts_patch"]
         )
         validators.check_facts_length(updated_facts)
+        validators.check_for_duplicate_names(updated_facts)
+        validators.check_for_empty_name_values(updated_facts)
         baseline.baseline_facts = updated_facts
+    except FactValidationError as e:
+        raise HTTPError(HTTPStatus.BAD_REQUEST, message=e.message)
     except (jsonpatch.JsonPatchException, jsonpointer.JsonPointerException):
         raise HTTPError(
             HTTPStatus.BAD_REQUEST, message="unable to apply patch to baseline"

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -206,6 +206,17 @@ BASELINE_PATCH = {
     ],
 }
 
+BASELINE_PATCH_EMPTY_VALUE = {
+    "display_name": "ABCDE",
+    "facts_patch": [{"op": "replace", "path": "/0/values/0/value", "value": ""}],
+}
+
+BASELINE_PATCH_EMPTY_NAME = {
+    "display_name": "ABCDE",
+    "facts_patch": [{"op": "replace", "path": "/0/values/0/name", "value": ""}],
+}
+
+
 BASELINE_PARTIAL_CONFLICT = {"display_name": "arch baseline", "facts_patch": []}
 BASELINE_TOUCH = {"display_name": "updated baseline", "facts_patch": []}
 CREATE_FROM_INVENTORY = {

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -386,6 +386,27 @@ class ApiPatchTests(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 400)
 
+        # attempt to use an empty fact name
+        response = self.client.patch(
+            "api/system-baseline/v1/baselines/%s" % patched_uuid,
+            headers=fixtures.AUTH_HEADER,
+            json=fixtures.BASELINE_PATCH_EMPTY_NAME,
+        )
+        self.assertIn("empty name in fact set", response.data.decode("utf-8"))
+        self.assertEqual(response.status_code, 400)
+
+        # attempt to use an empty fact value
+        response = self.client.patch(
+            "api/system-baseline/v1/baselines/%s" % patched_uuid,
+            headers=fixtures.AUTH_HEADER,
+            json=fixtures.BASELINE_PATCH_EMPTY_VALUE,
+        )
+        self.assertIn(
+            "empty value in fact set for cpu_sockets_renamed",
+            response.data.decode("utf-8"),
+        )
+        self.assertEqual(response.status_code, 400)
+
 
 class CreateFromInventoryTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
There were a couple of validations being done to new baselines that
were not also done to patch operations. This commit adds the same
validators to both.

Additionally, we now check if "name" or "value" is empty for any fact
and raise a 400 if needed.