### PR TITLE
check if category name is empty

### DIFF
--- a/system_baseline/validators.py
+++ b/system_baseline/validators.py
@@ -27,10 +27,10 @@ def check_for_empty_name_values(facts):
     for fact in facts:
         if "values" in fact:
             check_for_empty_name_values(fact["values"])
-        elif "name" in fact and not fact["name"]:
-            raise FactValidationError("empty name in fact set")
+        if "name" in fact and not fact["name"]:
+            raise FactValidationError("fact name cannot be empty")
         elif "value" in fact and not fact["value"]:
-            raise FactValidationError("empty value in fact set for %s" % fact["name"])
+            raise FactValidationError("value for %s cannot be empty" % fact["name"])
 
 
 def check_facts_length(facts):

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -392,7 +392,7 @@ class ApiPatchTests(unittest.TestCase):
             headers=fixtures.AUTH_HEADER,
             json=fixtures.BASELINE_PATCH_EMPTY_NAME,
         )
-        self.assertIn("empty name in fact set", response.data.decode("utf-8"))
+        self.assertIn("fact name cannot be empty", response.data.decode("utf-8"))
         self.assertEqual(response.status_code, 400)
 
         # attempt to use an empty fact value
@@ -402,7 +402,7 @@ class ApiPatchTests(unittest.TestCase):
             json=fixtures.BASELINE_PATCH_EMPTY_VALUE,
         )
         self.assertIn(
-            "empty value in fact set for cpu_sockets_renamed",
+            "value for cpu_sockets_renamed cannot be empty",
             response.data.decode("utf-8"),
         )
         self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
This commit re-enables the name check for categories (changing elif to
if). It also updates a few error strings to be more user friendly.