### PR TITLE
do not allow "value" and "values" in fact

### DIFF
--- a/system_baseline/validators.py
+++ b/system_baseline/validators.py
@@ -20,6 +20,19 @@ def check_for_duplicate_names(facts):
             raise FactValidationError("name %s declared more than once" % name)
 
 
+def check_for_value_values(facts):
+    """
+    check if any fields have "value" and "values" both defined
+    """
+    for fact in facts:
+        if "values" in fact and "value" in fact:
+            raise FactValidationError(
+                "fact %s cannot have value and values defined" % fact["name"]
+            )
+        elif "values" in fact:
+            check_for_value_values(fact["values"])
+
+
 def check_for_empty_name_values(facts):
     """
     check if any names are duplicated; raises an exception if duplicates are found.

--- a/system_baseline/views/v1.py
+++ b/system_baseline/views/v1.py
@@ -319,9 +319,7 @@ def create_baseline(system_baseline_in):
         baseline_facts = group_baselines(facts)
 
     try:
-        validators.check_facts_length(baseline_facts)
-        validators.check_for_duplicate_names(baseline_facts)
-        validators.check_for_empty_name_values(baseline_facts)
+        _validate_facts(baseline_facts)
     except FactValidationError as e:
         raise HTTPError(HTTPStatus.BAD_REQUEST, message=e.message)
 
@@ -447,9 +445,7 @@ def update_baseline(baseline_id, system_baseline_patch):
         updated_facts = jsonpatch.apply_patch(
             baseline.baseline_facts, system_baseline_patch["facts_patch"]
         )
-        validators.check_facts_length(updated_facts)
-        validators.check_for_duplicate_names(updated_facts)
-        validators.check_for_empty_name_values(updated_facts)
+        _validate_facts(updated_facts)
         baseline.baseline_facts = updated_facts
     except FactValidationError as e:
         raise HTTPError(HTTPStatus.BAD_REQUEST, message=e.message)
@@ -469,6 +465,16 @@ def update_baseline(baseline_id, system_baseline_patch):
         SystemBaseline.account == account_number, SystemBaseline.id == baseline_id
     )
     return [query.first().to_json()]
+
+
+def _validate_facts(facts):
+    """
+    helper to run common validations
+    """
+    validators.check_facts_length(facts)
+    validators.check_for_duplicate_names(facts)
+    validators.check_for_empty_name_values(facts)
+    validators.check_for_value_values(facts)
 
 
 @section.before_app_request

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -190,6 +190,17 @@ BASELINE_UNSORTED_LOAD = {
     "display_name": "duplicate cpu + mem baseline",
 }
 
+BASELINE_VALUE_VALUES_LOAD = {
+    "baseline_facts": [
+        {
+            "name": "arch",
+            "value": "x86_64",
+            "values": [{"name": "XXXXXX", "value": "YYYY"}],
+        }
+    ],
+    "display_name": "value values baseline",
+}
+
 BASELINE_PATCH = {
     "display_name": "ABCDE",
     "facts_patch": [

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -148,6 +148,18 @@ class ApiTests(unittest.TestCase):
             )
             self.assertEqual(response.status_code, 200)
 
+    def test_value_values(self):
+        response = self.client.post(
+            "api/system-baseline/v1/baselines",
+            headers=fixtures.AUTH_HEADER,
+            json=fixtures.BASELINE_VALUE_VALUES_LOAD,
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            "fact arch cannot have value and values defined",
+            response.data.decode("utf-8"),
+        )
+
     def test_fetch_baseline_list(self):
         response = self.client.get(
             "api/system-baseline/v1/baselines", headers=fixtures.AUTH_HEADER


### PR DESCRIPTION
Previously, we were not validating that "value" and "values" were not
both defined on the same fact. This commit adds that validator.

This commit also does a minor refactor to move all the validators to
one helper method.