### PR TITLE
expose the app version via API

### DIFF
--- a/system_baseline/openapi/api.spec.yaml
+++ b/system_baseline/openapi/api.spec.yaml
@@ -12,6 +12,18 @@ servers:
   - url: "{{ path_prefix }}{{ app_name }}/v1"
 
 paths:
+  /version:
+    get:
+      summary: get the service version
+      description: "get the service version"
+      operationId: system_baseline.views.v1.get_version
+      responses:
+        '200':
+          description: a service version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Version'
   /baselines:
     get:
       summary: fetch list of Baseline IDs
@@ -338,6 +350,12 @@ components:
                 type: string
               value:
                 type: string
+    Version:
+      required:
+        - version
+      properties:
+        version:
+          type: string
   parameters:
     orderByParam:
       name: order_by

--- a/system_baseline/version.py
+++ b/system_baseline/version.py
@@ -1,0 +1,1 @@
+app_version = "1.0.0"

--- a/system_baseline/views/v1.py
+++ b/system_baseline/views/v1.py
@@ -13,6 +13,7 @@ from kerlescan.inventory_service_interface import fetch_systems_with_profiles
 from kerlescan.service_interface import get_key_from_headers
 
 from system_baseline import metrics, app_config, validators
+from system_baseline.version import app_version
 from system_baseline.models import SystemBaseline, db
 from system_baseline.exceptions import FactValidationError
 
@@ -107,6 +108,13 @@ def _get_total_baseline_count():
     account_number = view_helpers.get_account_number(request)
     query = SystemBaseline.query.filter(SystemBaseline.account == account_number)
     return query.count()
+
+
+def get_version():
+    """
+    return the service version
+    """
+    return {"version": app_version}
 
 
 @metrics.baseline_fetch_requests.time()


### PR DESCRIPTION
This commit places a `__version__` variable in the module-level
`__init__.py` and exposes it via `/version` API call.

I think this method is correct given the example in
https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names.

A subsequent PR will enable revving the version via
`python-semantic-release`.