### PR TITLE
return a 400 if inventory UUID is invalid

### DIFF
--- a/system_baseline/views/v1.py
+++ b/system_baseline/views/v1.py
@@ -292,6 +292,7 @@ def create_baseline(system_baseline_in):
     if "baseline_facts" in system_baseline_in:
         baseline_facts = system_baseline_in["baseline_facts"]
     elif "inventory_uuid" in system_baseline_in:
+        _validate_uuids([system_baseline_in["inventory_uuid"]])
         auth_key = get_key_from_headers(request.headers)
         try:
             system_with_profile = fetch_systems_with_profiles(

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -246,6 +246,11 @@ CREATE_FROM_INVENTORY_LONG_NAME = {
     "inventory_uuid": "df925152-c45d-11e9-a1f0-c85b761454fa",
 }
 
+CREATE_FROM_INVENTORY_MALFORMED_UUID = {
+    "display_name": "created_from_inventory",
+    "inventory_uuid": "this is not a uuid",
+}
+
 
 SYSTEM_WITH_PROFILE = {
     "account": "9876543",

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -476,6 +476,15 @@ class CreateFromInventoryTests(unittest.TestCase):
             response.data.decode("utf-8"),
         )
 
+    def test_create_from_inventory_bad_uuid(self):
+        response = self.client.post(
+            "api/system-baseline/v1/baselines",
+            headers=fixtures.AUTH_HEADER,
+            json=fixtures.CREATE_FROM_INVENTORY_MALFORMED_UUID,
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("malformed UUID requested", response.data.decode("utf-8"))
+
 
 class ApiDuplicateTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Previously we were not checking the inventory UUID for correctness
before sending through to the inv service. This could result in a 500
error being returned instead of a 400.