### PR TITLE
add baseline metrics and fix other metrics

### DIFF
--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -11,4 +11,8 @@ BASELINE_DB_NAME=testdb FLASK_APP=system_baseline.app:get_flask_app_with_migrati
 
 BASELINE_DB_NAME=testdb prometheus_multiproc_dir=$TEMPDIR nosetests -sx --with-coverage --cover-package system_baseline  --cover-min-percentage 90 --cover-erase && rm -rf $TEMPDIR
 
+result=$?
+
 psql 'postgresql://insights:insights@localhost:5432' -c 'drop database testdb;'
+
+exit $result

--- a/system_baseline/metrics.py
+++ b/system_baseline/metrics.py
@@ -1,7 +1,7 @@
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter, Histogram, Gauge
 
 api_exceptions = Counter(
-    "system_baseline_api_exceptions", "count of exceptions raised on public API"
+    "baseline_api_exceptions", "count of exceptions raised on public API"
 )
 
 baseline_create_requests = Histogram(
@@ -21,15 +21,43 @@ baseline_delete_requests = Histogram(
 )
 
 inventory_service_requests = Histogram(
-    "drift_inventory_service_requests", "inventory service call stats"
+    "baseline_inventory_service_requests", "inventory service call stats"
 )
 
 inventory_service_exceptions = Counter(
-    "drift_inventory_service_exceptions", "count of exceptions raised by inv service"
+    "baseline_inventory_service_exceptions", "count of exceptions raised by inv service"
 )
 
-systems_compared_no_sysprofile = Histogram(
-    "drift_systems_compared_no_sysprofile",
-    "count of systems without system profile" "compared in each request",
-    buckets=[2, 4, 8, 16, 32, 64, 128, 256],
+
+inventory_service_no_profile = Counter(
+    "baseline_inventory_service_no_profile",
+    "count of systems fetched without a profile",
+)
+
+baseline_count = Gauge(
+    "baseline_count", "count of total number of baselines", multiprocess_mode="max"
+)
+
+baseline_account_count = Gauge(
+    "baseline_account_count",
+    "count of total number of accounts with baselines",
+    multiprocess_mode="max",
+)
+
+baseline_account_count_ones = Gauge(
+    "baseline_account_count_ones",
+    "number of accounts with zero to ten baselines",
+    multiprocess_mode="max",
+)
+
+baseline_account_count_tens = Gauge(
+    "baseline_account_count_tens",
+    "number of accounts with ten to one hundred baselines",
+    multiprocess_mode="max",
+)
+
+baseline_account_count_hundred_plus = Gauge(
+    "baseline_account_count_hundred_plus",
+    "number of accounts with over one hundred baselines",
+    multiprocess_mode="max",
 )

--- a/system_baseline/mgmt_views/v0.py
+++ b/system_baseline/mgmt_views/v0.py
@@ -1,11 +1,45 @@
 from flask import jsonify
 
 from kerlescan.metrics_registry import get_registry
+from system_baseline.models import SystemBaseline, db
+from system_baseline import metrics as baseline_metrics
 
 from prometheus_client import generate_latest
 
+from sqlalchemy.sql import text
+
+RANGES = text(
+    "select count(*) from"
+    " (select count(account) from system_baselines group by account) x"
+    " where count between :low and :high"
+)
+
+BIGINT_MAX = 9223372036854775807
+
+
+def _update_baseline_counts():
+    """
+    The baseline counts are updated when metrics are fetched via SQL
+    """
+    total_baselines = SystemBaseline.query.count()
+    total_accounts = SystemBaseline.query.distinct(SystemBaseline.account.name).count()
+    total_accounts_ones = db.engine.execute(RANGES, low=0, high=10).scalar()
+    total_accounts_tens = db.engine.execute(RANGES, low=10, high=100).scalar()
+    total_accounts_hundred_plus = db.engine.execute(
+        RANGES, low=100, high=BIGINT_MAX
+    ).scalar()
+
+    baseline_metrics.baseline_count.set(total_baselines)
+    baseline_metrics.baseline_account_count.set(total_accounts)
+    baseline_metrics.baseline_account_count_ones.set(total_accounts_ones)
+    baseline_metrics.baseline_account_count_tens.set(total_accounts_tens)
+    baseline_metrics.baseline_account_count_hundred_plus.set(
+        total_accounts_hundred_plus
+    )
+
 
 def metrics():
+    _update_baseline_counts()
     registry = get_registry()
     prometheus_data = generate_latest(registry)
     return prometheus_data

--- a/system_baseline/views/v1.py
+++ b/system_baseline/views/v1.py
@@ -266,7 +266,7 @@ def get_event_counters():
     small helper to create a dict of event counters
     """
     return {
-        "systems_compared_no_sysprofile": metrics.systems_compared_no_sysprofile,
+        "systems_compared_no_sysprofile": metrics.inventory_service_no_profile,
         "inventory_service_requests": metrics.inventory_service_requests,
         "inventory_service_exceptions": metrics.inventory_service_exceptions,
     }


### PR DESCRIPTION
This commit adds two additional metrics that track the total number of
baselines in the DB, and total number of accounts with baselines in
the DB.

It also fixes up some incorrectly named metrics that were copied from
drift a long time ago.

NOTE: I will need to test this after it is deployed to multiple pods
to confirm I'm using the right `multiprocess_mode`. I believe `max` is
correct but will confirm.