### PR TITLE
metrics fix

### DIFF
--- a/system_baseline/metrics.py
+++ b/system_baseline/metrics.py
@@ -28,8 +28,8 @@ inventory_service_exceptions = Counter(
     "baseline_inventory_service_exceptions", "count of exceptions raised by inv service"
 )
 
-
-inventory_service_no_profile = Counter(
+# kerlescan expects this to be Histogram
+inventory_service_no_profile = Histogram(
     "baseline_inventory_service_no_profile",
     "count of systems fetched without a profile",
 )


### PR DESCRIPTION
We were previously passing in a Counter to kerlescan as part of the
metrics fixups in a recent commit. However, Counters do not implement
`observe`. This caused a 500 to be raised when cloning baselines from
systems.

This commit changes the Counter back to Histogram.