### PR TITLE
docs: add commit msg guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,4 +115,18 @@ You can also use PATCH calls to a UUID with data like so:
     }
 ```
 
+# contributing to this repo
+
+Please ensure the following when making PRs:
+
+ * tests pass (`./run_unit_tests.sh`)
+ * commit is of the following form (see https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits):
+
+```
+fix: patch title
+
+summary of fix
+
+```
+
 


### PR DESCRIPTION
This commit adds message guidelines. These guidelines are needed for
python-semantic-version to figure out how to number the next release.