### PR TITLE
fix: check for duplicate uuid

### DIFF
--- a/system_baseline/views/v1.py
+++ b/system_baseline/views/v1.py
@@ -377,6 +377,12 @@ def _validate_uuids(uuids):
             message="malformed UUID requested (%s)" % ",".join(uuids),
         )
 
+    uuid_set = set(uuids)
+    if len(uuid_set) < len(uuids):
+        raise HTTPError(
+            HTTPStatus.BAD_REQUEST, message="duplicate UUIDs specified in request"
+        )
+
 
 def _sort_baseline_facts(baseline_facts):
     """

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -217,6 +217,20 @@ class ApiTests(unittest.TestCase):
         # check that the ascending result is the inverse of the descending result
         self.assertEqual(desc_result["data"][::-1], asc_result["data"])
 
+    def test_fetch_duplicate_uuid(self):
+        response = self.client.get(
+            "api/system-baseline/v1/baselines?display_name=arch",
+            headers=fixtures.AUTH_HEADER,
+        )
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.data)
+        uuid = result["data"][0]["id"]
+        response = self.client.get(
+            "api/system-baseline/v1/baselines/%s,%s" % (uuid, uuid),
+            headers=fixtures.AUTH_HEADER,
+        )
+        self.assertEqual(response.status_code, 400)
+
     def test_fetch_baseline_search(self):
         response = self.client.get(
             "api/system-baseline/v1/baselines?display_name=arch",


### PR DESCRIPTION
Previously, we would not raise an error if someone requested the same
UUID more than once in the same request.

This commit changes that behavior. We now raise a 400.