### PR TITLE
fix: do not allow extremely long fact names/values

### DIFF
--- a/system_baseline/validators.py
+++ b/system_baseline/validators.py
@@ -56,6 +56,25 @@ def check_facts_length(facts):
         )
 
 
+def check_name_value_length(facts):
+    """
+    check the following lengths:
+        * name is over 500 char
+        * value is over 1000 char
+    """
+    for fact in facts:
+        if "values" in fact:
+            check_name_value_length(fact["values"])
+        if "name" in fact and len(fact["name"]) > 500:
+            raise FactValidationError(
+                "fact name %s is over 500 characters" % fact["name"]
+            )
+        elif "value" in fact and len(fact["value"]) > 1000:
+            raise FactValidationError(
+                "value %s is over 1000 characters" % fact["value"]
+            )
+
+
 def check_uuids(baseline_ids):
     """
     helper method to test if a UUID is properly formatted. Will raise an

--- a/system_baseline/views/v1.py
+++ b/system_baseline/views/v1.py
@@ -494,6 +494,7 @@ def _validate_facts(facts):
     validators.check_for_duplicate_names(facts)
     validators.check_for_empty_name_values(facts)
     validators.check_for_value_values(facts)
+    validators.check_name_value_length(facts)
 
 
 @section.before_app_request

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -201,6 +201,47 @@ BASELINE_VALUE_VALUES_LOAD = {
     "display_name": "value values baseline",
 }
 
+# >500 char name
+BASELINE_LONG_NAME_LOAD = {
+    "baseline_facts": [
+        {
+            "name": "archxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            "xxxxxxxx",
+            "value": "x86_64",
+        }
+    ],
+    "display_name": "long name baseline",
+}
+
+# >1000 char name
+BASELINE_LONG_VALUE_LOAD = {
+    "baseline_facts": [
+        {
+            "name": "arch",
+            "value": "x86_64xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        }
+    ],
+    "display_name": "long value baseline",
+}
+
 BASELINE_PATCH = {
     "display_name": "ABCDE",
     "facts_patch": [

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -66,6 +66,27 @@ class InvalidFactsTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 400)
 
+    def test_long_name_value(self):
+        response = self.client.post(
+            "api/system-baseline/v1/baselines",
+            headers=fixtures.AUTH_HEADER,
+            json=fixtures.BASELINE_LONG_NAME_LOAD,
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            "is over 500 characters", response.data.decode("utf-8"),
+        )
+
+        response = self.client.post(
+            "api/system-baseline/v1/baselines",
+            headers=fixtures.AUTH_HEADER,
+            json=fixtures.BASELINE_LONG_VALUE_LOAD,
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            "is over 1000 characters", response.data.decode("utf-8"),
+        )
+
 
 class ApiSortTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
We previously did not limit how long a fact name or value was in a
system baseline. This commit caps names at 500 characters and values
at 1000.