### PR TITLE
Change default db name to 'baselinedb'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - psql -c "CREATE USER insights WITH PASSWORD 'insights';"
   - psql -c "ALTER USER insights CREATEDB"
 # we use `testdb` for the tests; this is just to create a place for insights user to have
-  - psql -c 'create database insights;' -U postgres
+  - psql -c 'create database baselinedb;' -U postgres
   - wget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.1.1/openapi-generator-cli-4.1.1.jar
 
 script:

--- a/dev.yml
+++ b/dev.yml
@@ -6,6 +6,6 @@ services:
         environment:
             POSTGRES_PASSWORD: insights
             POSTGRES_USER: insights
-            POSTGRES_DB: insights
+            POSTGRES_DB: baselinedb
         ports: 
             - "5432:5432"

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -5,7 +5,7 @@
 
 TEMPDIR=`mktemp -d`
 
-psql 'postgresql://insights:insights@localhost:5432' -c 'create database testdb;'
+psql 'postgresql://insights:insights@localhost:5432/baselinedb' -c 'create database testdb;'
 
 BASELINE_DB_NAME=testdb FLASK_APP=system_baseline.app:get_flask_app_with_migration flask db upgrade
 
@@ -13,6 +13,6 @@ BASELINE_DB_NAME=testdb prometheus_multiproc_dir=$TEMPDIR nosetests -sx --with-c
 
 result=$?
 
-psql 'postgresql://insights:insights@localhost:5432' -c 'drop database testdb;'
+psql 'postgresql://insights:insights@localhost:5432/baselinedb' -c 'drop database testdb;'
 
 exit $result

--- a/system_baseline/db_config.py
+++ b/system_baseline/db_config.py
@@ -5,7 +5,7 @@ import os
 _db_user = os.getenv("BASELINE_DB_USER", "insights")
 _db_password = os.getenv("BASELINE_DB_PASS", "insights")
 _db_host = os.getenv("BASELINE_DB_HOST", "localhost")
-_db_name = os.getenv("BASELINE_DB_NAME", "insights")
+_db_name = os.getenv("BASELINE_DB_NAME", "baselinedb")
 
 db_uri = f"postgresql://{_db_user}:{_db_password}@{_db_host}/{_db_name}"
 db_pool_timeout = int(os.getenv("BASELINE_DB_POOL_TIMEOUT", "5"))


### PR DESCRIPTION
The way that the DB was set up in app-interface, the `baselinedb` name was not provided in the terraform configs. I guess someone manually created that database in postgres after the RDS instance was provisioned.

So at the moment, the secret for the DB inserted by app-sre's tools has a null `db.name`. Due to some complexities on their end, the easiest approach is just going to be for the app to change its default DB name when the env var set by `db.name` is null/absent.