### PR TITLE
Improved error handling when adding duplicate system to baseline

### DIFF
--- a/system_baseline/models.py
+++ b/system_baseline/models.py
@@ -63,7 +63,15 @@ class SystemBaseline(db.Model):
             json_dict["system_ids"] = self.mapped_system_ids()
         return json_dict
 
+    def validate_existing_system(self, system_id):
+        for mapped_system in self.mapped_systems:
+            if system_id == str(mapped_system.system_id):
+                raise ValueError(
+                    "System {} already associated with this baseline".format(system_id)
+                )
+
     def add_mapped_system(self, system_id):
+        self.validate_existing_system(system_id)
         new_mapped_system = SystemBaselineMappedSystem(system_id=system_id, account=self.account)
         self.mapped_systems.append(new_mapped_system)
         db.session.add(new_mapped_system)


### PR DESCRIPTION
Now if users try to associate an already associated system to the baseline, our response code is 400 with a comprehensive message instead of 500.

Request:
Assuming {{baseline_UUID}} is
`POST: {{BASELINE_BASE_CI_URL}}/api/system-baseline/v1/baselines/{{baseline_UUID}}/systems`

Body:
`{ "system_ids": [ "{{SOME_SYSTEM_ID_ALREADY_ASSOCIATED}}" ] }`

Response:
Responde code: 400
`{ "message": "System(s) already associated with this baseline" }`

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
