### PR TITLE
[DRFT-582] Fix validation errors for name and fact name

### DIFF
--- a/system_baseline/validators.py
+++ b/system_baseline/validators.py
@@ -9,14 +9,21 @@ def check_for_duplicate_names(facts):
     check if any names are duplicated; raises an exception if duplicates are found.
     """
     names = []
+    categories = []
     for fact in facts:
-        names.append(fact["name"])
         if "values" in fact:
+            categories.append(fact["name"])
             check_for_duplicate_names(fact["values"])
+        else:
+            names.append(fact["name"])
 
     for name in names:
         if names.count(name) > 1:
-            raise FactValidationError("name %s declared more than once" % name)
+            raise FactValidationError("A fact with this name already exists.")
+
+    for category in categories:
+        if categories.count(category) > 1:
+            raise FactValidationError("A category with this name already exists.")
 
 
 def check_for_value_values(facts):
@@ -32,7 +39,7 @@ def check_for_value_values(facts):
 
 def check_for_empty_name_values(facts):
     """
-    check if any names are duplicated; raises an exception if duplicates are found.
+    check if any name values are empty; raises an exception if found.
     """
     for fact in facts:
         if "values" in fact:

--- a/system_baseline/views/v1.py
+++ b/system_baseline/views/v1.py
@@ -425,7 +425,7 @@ def create_baseline(system_baseline_in):
 
     db.session.commit()  # commit now so we get a created/updated time before json conversion
 
-    message = "creat baselines"
+    message = "create baselines"
     current_app.logger.audit(message, request=request)
 
     return baseline.to_json()
@@ -446,7 +446,7 @@ def _check_for_existing_display_name(display_name, account_number):
     current_app.logger.audit(message, request=request)
 
     if count > 0:
-        message = "display_name '%s' already used for this account" % display_name
+        message = "A baseline with this name already exists."
         current_app.logger.audit(message, request=request, success=False)
         raise HTTPError(
             HTTPStatus.BAD_REQUEST,
@@ -555,10 +555,7 @@ def update_baseline(baseline_id, system_baseline_patch):
     )
 
     if existing_display_name_query.count() > 0:
-        message = (
-            "display_name '%s' already used for this account"
-            % system_baseline_patch["display_name"]
-        )
+        message = "A baseline with this name already exists."
         current_app.logger.audit(message, request=request, success=False)
         raise HTTPError(
             HTTPStatus.BAD_REQUEST,

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -583,7 +583,7 @@ class ApiDuplicateTests(ApiTest):
             json=fixtures.BASELINE_DUPLICATES_LOAD,
         )
         self.assertIn(
-            "name nested_cpu_sockets declared more than once",
+            "A fact with this name already exists.",
             response.data.decode("utf-8"),
         )
 
@@ -592,15 +592,15 @@ class ApiDuplicateTests(ApiTest):
             headers=fixtures.AUTH_HEADER,
             json=fixtures.BASELINE_DUPLICATES_TWO_LOAD,
         )
-        self.assertIn("memory declared more than once", response.data.decode("utf-8"))
+        self.assertIn("A fact with this name already exists.", response.data.decode("utf-8"))
 
+        # test that a category and fact can have the same name
         response = self.client.post(
             "api/system-baseline/v1/baselines",
             headers=fixtures.AUTH_HEADER,
             json=fixtures.BASELINE_DUPLICATES_THREE_LOAD,
         )
-        self.assertEqual(response.status_code, 400)
-        self.assertIn("memory declared more than once", response.data.decode("utf-8"))
+        self.assertEqual(response.status_code, 200)
 
     def test_create_baseline_with_leading_trailing_whitespace(self):
         response = self.client.post(


### PR DESCRIPTION
Before, the validation errors for duplicate baseline names and fact names were not matching the mock ups. The sentences were also not in sentence case. This PR properly aligns them with the mock up.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
