### PR TITLE
[DRFT-575] Change whitespace validation message to sentence case

### DIFF
--- a/system_baseline/views/v1.py
+++ b/system_baseline/views/v1.py
@@ -459,7 +459,7 @@ def _check_for_whitespace_in_display_name(display_name):
     check to see if the display name has leading or trailing whitespace
     """
     if display_name and (not validators.check_whitespace(display_name)):
-        message = "baseline name cannot have leading or trailing whitespace"
+        message = "Baseline name cannot have leading or trailing whitespace."
         current_app.logger.audit(message, request=request, success=False)
         raise HTTPError(
             HTTPStatus.BAD_REQUEST,

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -595,6 +595,10 @@ class ApiDuplicateTests(ApiTest):
             json=fixtures.BASELINE_NAME_LEADING_WHITESPACE,
         )
         self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            "Baseline name cannot have leading or trailing whitespace.",
+            response.data.decode("utf-8"),
+        )
 
         response = self.client.post(
             "api/system-baseline/v1/baselines",
@@ -602,6 +606,10 @@ class ApiDuplicateTests(ApiTest):
             json=fixtures.BASELINE_NAME_TRAILING_WHITESPACE,
         )
         self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            "Baseline name cannot have leading or trailing whitespace.",
+            response.data.decode("utf-8"),
+        )
 
 
 class ApiPaginationTests(ApiTest):


### PR DESCRIPTION
Before, the error message for leading and trailing whitespace started with a lowercase letter. This change updates the message to sentence case and adds a period.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
