### PR TITLE
[DRFT-578] Change fact/value whitespace validation to sentence case

### DIFF
--- a/system_baseline/validators.py
+++ b/system_baseline/validators.py
@@ -51,12 +51,12 @@ def check_for_invalid_whitespace_name_values(facts):
         if "values" in fact:
             check_for_invalid_whitespace_name_values(fact["values"])
         if "name" in fact and not check_whitespace(fact["name"]):
-            raise FactValidationError("fact name cannot have leading or trailing whitespace")
+            raise FactValidationError("Fact name cannot have leading or trailing whitespace.")
         elif "value" in fact:
             if not isinstance(fact["value"], list):
                 if not check_whitespace(fact["value"]):
                     raise FactValidationError(
-                        "value for %s cannot have leading or trailing whitespace" % fact["name"]
+                        "Value for %s cannot have leading or trailing whitespace." % fact["name"]
                     )
 
 

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -471,6 +471,9 @@ class ApiPatchTests(ApiTest):
             json=fixtures.BASELINE_PATCH_LEADING_WHITESPACE_NAME,
         )
         self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            "Fact name cannot have leading or trailing whitespace.", response.data.decode("utf-8")
+        )
 
         # attempt to add a fact with trailing whitespace
         response = self.client.patch(
@@ -479,6 +482,9 @@ class ApiPatchTests(ApiTest):
             json=fixtures.BASELINE_PATCH_TRAILING_WHITESPACE_NAME,
         )
         self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            "Fact name cannot have leading or trailing whitespace.", response.data.decode("utf-8")
+        )
 
         # attempt to add a value with leading whitespace
         response = self.client.patch(
@@ -487,6 +493,10 @@ class ApiPatchTests(ApiTest):
             json=fixtures.BASELINE_PATCH_LEADING_WHITESPACE_VALUE,
         )
         self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            "Value for cpu_sockets_renamed cannot have leading or trailing whitespace.",
+            response.data.decode("utf-8"),
+        )
 
         # attempt to add a value with trailing whitespace
         response = self.client.patch(
@@ -495,6 +505,10 @@ class ApiPatchTests(ApiTest):
             json=fixtures.BASELINE_PATCH_TRAILING_WHITESPACE_VALUE,
         )
         self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            "Value for cpu_sockets_renamed cannot have leading or trailing whitespace.",
+            response.data.decode("utf-8"),
+        )
 
 
 class CreateFromInventoryTests(ApiTest):


### PR DESCRIPTION
Before, the error message for leading and trailing whitespace in facts and values started with a lowercase letter. This change updates the message to sentence case and adds a period.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
