### PR TITLE
[DRFT-808] Add mapped system count to get_baselines

### DIFF
--- a/system_baseline/models.py
+++ b/system_baseline/models.py
@@ -3,6 +3,7 @@ import uuid
 from datetime import datetime
 
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import relationship, validates
 from sqlalchemy.schema import ForeignKey, UniqueConstraint
@@ -109,3 +110,12 @@ class SystemBaselineMappedSystem(db.Model):
     def delete_by_system_ids(cls, system_ids, account_number):
         cls.query.filter(cls.system_id.in_(system_ids)).delete(synchronize_session="fetch")
         db.session.commit()
+
+    @classmethod
+    def get_mapped_system_count(cls, account_number):
+        return (
+            cls.query.with_entities(cls.system_baseline_id, func.count(cls.system_baseline_id))
+            .group_by(cls.system_baseline_id)
+            .filter(cls.account == account_number)
+            .all()
+        )

--- a/system_baseline/views/v1.py
+++ b/system_baseline/views/v1.py
@@ -22,7 +22,7 @@ from system_baseline.global_helpers import (
     ensure_rbac_notifications_read,
     ensure_rbac_notifications_write,
 )
-from system_baseline.models import SystemBaseline, db
+from system_baseline.models import SystemBaseline, SystemBaselineMappedSystem, db
 from system_baseline.version import app_version
 
 
@@ -242,6 +242,12 @@ def get_baselines(limit, offset, order_by, order_how, display_name=None):
     current_app.logger.audit(message, request=request)
 
     json_list = [baseline.to_json(withhold_facts=True) for baseline in query_results]
+
+    mapped_systems_count = SystemBaselineMappedSystem.get_mapped_system_count(account_number)
+    for baseline_count in mapped_systems_count:
+        for baseline in json_list:
+            if baseline["id"] == str(baseline_count[0]):
+                baseline["mapped_system_count"] = baseline_count[1]
 
     return build_paginated_baseline_list_response(
         limit,

--- a/tests/test_db_models.py
+++ b/tests/test_db_models.py
@@ -14,6 +14,11 @@ baseline_facts = [
 account1 = "00000001"
 account2 = "00000002"
 
+baseline_id1 = uuid.uuid4()
+baseline_id2 = uuid.uuid4()
+baseline_id3 = uuid.uuid4()
+baseline_id4 = uuid.uuid4()
+
 system_id1 = uuid.uuid4()
 system_id2 = uuid.uuid4()
 system_id3 = uuid.uuid4()
@@ -51,6 +56,7 @@ class DbModelTest(unittest.TestCase):
         rows = [
             SystemBaseline(
                 account=account1,
+                id=baseline_id1,
                 display_name="baseline1",
                 baseline_facts=baseline_facts,
                 mapped_systems=[
@@ -70,6 +76,7 @@ class DbModelTest(unittest.TestCase):
             ),
             SystemBaseline(
                 account=account1,
+                id=baseline_id2,
                 display_name="baseline2",
                 baseline_facts=baseline_facts,
                 mapped_systems=[
@@ -85,6 +92,7 @@ class DbModelTest(unittest.TestCase):
             ),
             SystemBaseline(
                 account=account2,
+                id=baseline_id3,
                 display_name="baseline3",
                 baseline_facts=baseline_facts,
                 mapped_systems=[
@@ -100,6 +108,7 @@ class DbModelTest(unittest.TestCase):
             ),
             SystemBaseline(
                 account=account2,
+                id=baseline_id4,
                 display_name="baseline4",
                 baseline_facts=baseline_facts,
                 mapped_systems=[
@@ -339,3 +348,18 @@ class SystemBaselineMappedSystemTest(DbModelTest):
         self.assertIn(system_id7, system_ids)
         self.assertNotIn(system_id8, system_ids)
         self.assertIn(system_id9, system_ids)
+
+    def test_get_mapped_system_count(self):
+        self.populate_db_with_stuff()
+
+        mapped_systems_count = SystemBaselineMappedSystem.get_mapped_system_count(account1)
+
+        self.assertEqual(
+            sorted(mapped_systems_count), sorted([(baseline_id1, 3), (baseline_id2, 2)])
+        )
+
+        mapped_systems_count = SystemBaselineMappedSystem.get_mapped_system_count(account2)
+
+        self.assertEqual(
+            sorted(mapped_systems_count), sorted([(baseline_id3, 2), (baseline_id4, 3)])
+        )

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -836,3 +836,9 @@ class ApiSystemsAssociationTests(ApiTest):
 
         for system_id in system_ids:
             self.assertIn(system_id, response_system_ids)
+
+    def test_get_system_count_for_baselines(self):
+        response = self.client.get("api/system-baseline/v1/baselines", headers=fixtures.AUTH_HEADER)
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.data)
+        self.assertEqual(result["data"][0]["mapped_system_count"], 3)


### PR DESCRIPTION
This PR queries the SystemBaselineMappedSystem model for a count of systems that have been associated with each baseline id associated with an account. This data is returned as part of get_baselines as an extra key/value pair for each baseline.
```
{
    'id': <some_id>,
    'account': '1234',
    'display_name': 'baseline',
    'fact_count': 2,
    'created': '2021-09-22T17:32:25.015699Z',
    'updated': '2021-09-22T17:32:25.015706Z',
    'mapped_system_count': 3
}
```

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [x] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
