### PR TITLE
Adding FLOORIST_DISABLED Parameter to clowdapp.yml

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -26,6 +26,7 @@ objects:
         - name: floorist
           schedule: ${FLOORIST_SCHEDULE}
           suspend: ${{FLOORIST_SUSPEND}}
+          disabled: ${{FLOORIST_DISABLED}}
           concurrencyPolicy: Forbid
           podSpec:
             image: ${FLOORIST_IMAGE}:${FLOORIST_IMAGE_TAG}
@@ -259,6 +260,9 @@ parameters:
     description: Disable Floorist cronjob execution
     required: true
     value: 'true'
+  - name: FLOORIST_DISABLED
+    description: Determines whether to build the Floorist Job.
+    value: 'false'
   - description: Floorist image name
     name: FLOORIST_IMAGE
     value: quay.io/cloudservices/floorist


### PR DESCRIPTION
## Overview
This MR adds the `FLOORIST_DISABLED` parameter to the `clowdapp.yml`. This adds the ability to disable the creation of the Floorist Job, in its entirety, within ephemeral/alternative environments.

The `FLOORIST_DISABLED` parameter ensures that Floorist Container is not built in a more restrictive environment, as opposed to using `FLOORIST_SUSPEND`, in which the container is still created but not run. 

Creating and not running the Floorist Container still add to the list of images that must be monitored/maintained for vulnerability management.


## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist
