### PR TITLE
Use tmp dir in build_deploy.sh

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -11,6 +11,18 @@ if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
     exit 1
 fi
 
+# Create tmp dir to store data in during job run (do NOT store in $WORKSPACE)
+export TMP_JOB_DIR=$(mktemp -d -p "$HOME" -t "jenkins-${JOB_NAME}-${BUILD_NUMBER}-XXXXXX")
+echo "job tmp dir location: $TMP_JOB_DIR"
+
+function job_cleanup() {
+    echo "cleaning up job tmp dir: $TMP_JOB_DIR"
+    rm -fr $TMP_JOB_DIR
+}
+
+trap job_cleanup EXIT ERR SIGINT SIGTERM
+
+
 if [[ "$GIT_BRANCH" == "origin/security-compliance" ]]; then
     PUSH_TAG="${SECURITY_COMPLIANCE_TAG}"
 else
@@ -19,7 +31,7 @@ fi
 
 if test -f /etc/redhat-release && grep -q -i "release 7" /etc/redhat-release; then
     # on RHEL7, use docker
-    DOCKER_CONF="$PWD/.docker"
+    DOCKER_CONF="${$TMP_JOB_DIR}/.docker"
     mkdir -p "$DOCKER_CONF"
     docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
     docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
@@ -33,7 +45,7 @@ if test -f /etc/redhat-release && grep -q -i "release 7" /etc/redhat-release; th
 
 else
     # on RHEL8 or anything else, use podman
-    AUTH_CONF_DIR="$(pwd)/.podman"
+    AUTH_CONF_DIR="${$TMP_JOB_DIR}/.podman"
     mkdir -p $AUTH_CONF_DIR
     export REGISTRY_AUTH_FILE="$AUTH_CONF_DIR/auth.json"
     podman login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io


### PR DESCRIPTION
Use tmp dir instead of $WORKSPACE to store docker config in build_deploy.sh